### PR TITLE
Replace empty blocks with nil parameters

### DIFF
--- a/BlueRocketFuelCore/ui/BROptionsTray/BROptionsTray.m
+++ b/BlueRocketFuelCore/ui/BROptionsTray/BROptionsTray.m
@@ -96,8 +96,7 @@ typedef void (^CompletionBlock)();
                          transform = CATransform3DTranslate(transform, -12, 0, 0);
                          self.imageView.layer.transform = transform;
                      }
-                     completion:^(BOOL finished) {
-                     }
+                     completion:nil
      ];
     
     
@@ -111,8 +110,7 @@ typedef void (^CompletionBlock)();
 }
 
 - (void)hide {
-    [self hideWithCompletion:^{
-    }];
+    [self hideWithCompletion:nil];
 }
 
 - (void)hideWithCompletion:(void (^)())completion {


### PR DESCRIPTION
Empty blocks still take up CPU and memory resources to process as they are ObjC objects behind the scenes. Better to pass in nil if we don't want to do anything in the block.